### PR TITLE
Can now parse numbers and currencies with delimiters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
-module github.com/ivahaev/go-xlsx-templater
+module github.com/flume/go-xlsx-templater
 
 go 1.13
 
 require (
 	github.com/aymerick/raymond v2.0.2+incompatible
+	github.com/davecgh/go-spew v1.1.1
 	github.com/tealeg/xlsx v1.0.5
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aymerick/raymond v2.0.2+incompatible h1:VEp3GpgdAnv9B2GFyTvqgcKvY+mfKMjPOA3SbKLtnU0=
 github.com/aymerick/raymond v2.0.2+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/xlst.go
+++ b/xlst.go
@@ -18,6 +18,7 @@ var (
 	rangeRgx    = regexp.MustCompile(`\{\{\s*range\s+(\w+)\s*\}\}`)
 	rangeEndRgx = regexp.MustCompile(`\{\{\s*end\s*\}\}`)
 	numRgx      = regexp.MustCompile(`^#-?[0-9]+(\.[0-9]+)?`)
+	currRgx     = regexp.MustCompile(`^\$-?[0-9]+(\.[0-9]+)?`)
 )
 
 // Xlst Represents template struct
@@ -215,6 +216,14 @@ func renderCell(cell *xlsx.Cell, ctx interface{}) error {
 			return err
 		}
 		cell.SetFloat(f)
+
+	} else if currRgx.MatchString(out) {
+		f, err := strconv.ParseFloat(strings.TrimPrefix(out, "$"), 64)
+		if err != nil {
+			return err
+		}
+		cell.SetFloatWithFormat(f, `_("$"* #,##0.00_);_("$"* \(#,##0.00\);_("$"* "-"??_);_(@_)`)
+
 	} else {
 		cell.Value = out
 	}


### PR DESCRIPTION
Edited the xlsx templater to allow for numbers and currencies to be parsed correctly into excel

